### PR TITLE
Add `defaultInit` on `FetchAdapter`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,20 @@ const httpAdapter = new HttpAdapters.FetchHttpAdapter(
 );
 ```
 
+##### Set `defaultInit`
+
+Set a default request `init` options that will be merged with all the request options made by the adapter:
+
+```js
+const defaultInit = { mode: 'cors' };
+const httpAdapter = new HttpAdapters.FetchHttpAdapter(fetch, defaultInit);
+
+client.defaultInit.credentials = 'include';
+
+console.log(client.defaultInit);
+// { mode: 'cors', credentials: 'include' }
+```
+
 ### Client
 
 Set the HTTP adapter.
@@ -197,9 +211,7 @@ Set default HTTP headers to apply to each HTTP requests.
 ```ts
 const username = 'username';
 const password = 'password';
-const defaultHttpHeaders = {
-  'Authorization': 'Basic ' + btoa(username + ':' + password)
-};
+const defaultHttpHeaders = { 'Authorization': 'Basic ' + btoa(username + ':' + password) };
 
 const client = new JsonApi.Client(httpAdapter, defaultHttpHeaders);
 

--- a/__tests__/HttpAdapters/FetchHttpAdapter.test.ts
+++ b/__tests__/HttpAdapters/FetchHttpAdapter.test.ts
@@ -56,4 +56,51 @@ describe.only('HttpAdapters.FetchHttpAdapter', () => {
       });
     });
   });
+
+  describe('with defaultInit', () => {
+    describe('with headers', () => {
+      beforeEach(() => {
+        httpAdapter.defaultInit = {
+          method: 'PATCH',
+          mode: 'cors',
+          credentials: 'include',
+          headers: {
+            'x-foo': 'bar',
+            'x-csrf-token': ''
+          },
+          body: '[]'
+        };
+      });
+
+      test('calls fetch function with merged init', () => {
+        httpAdapter.request(request);
+
+        expect(fetchFunction.mock.calls.length).toBe(1);
+        expect(fetchFunction.mock.calls[0]).toEqual([
+          'https://examples.com/',
+          {
+            method: 'POST',
+            mode: 'cors',
+            credentials: 'include',
+            headers: {
+              'Content-Type': 'application/json',
+              'x-csrf-token': '',
+              'x-foo': 'bar'
+            },
+            body: '{"foo":"bar"}'
+          }
+        ]);
+      });
+
+      test('resolves with response', async () => {
+        await expect(httpAdapter.request(request)).resolves.toEqual({
+          body: '<!DOCTYPE html>',
+          headers: {
+            'content-type': 'text/html'
+          },
+          status: 200
+        });
+      });
+    });
+  });
 });


### PR DESCRIPTION
Set a default request `init` options that will be merged with all the request options made by the `FetchAdapter`.

```js
const defaultInit = { mode: 'cors' };
const httpAdapter = new HttpAdapters.FetchHttpAdapter(fetch, defaultInit);

client.defaultInit.credentials = 'include';

console.log(client.defaultInit);
// { mode: 'cors', credentials: 'include' }
```

References:
- #1